### PR TITLE
Fix typos in Stairs component comments

### DIFF
--- a/components/Stairs.jsx
+++ b/components/Stairs.jsx
@@ -13,7 +13,7 @@ const stairAnimation = {
   },
 };
 
-// calculate the reverse index fot staggred delay
+// calculate the reverse index for staggered delay
 const reverseIndex = (index) => {
   const totalSteps = 24; // number of steps
   return totalSteps - index - 1;
@@ -24,7 +24,7 @@ const Stairs = () => {
     <>
       {/* render 6 motion divs, each representing a step of the stairs.
   Each div will have the same animation defined by the stairsAnimation object.
-  The delay for each div is calculated sinamically based on it's reversed index,
+  The delay for each div is calculated dynamically based on its reversed index,
   creating a staggered effect with decreasing delay for each subsequent step.
   */}
       {[...Array(24)].map((_, index) => {


### PR DESCRIPTION
## Summary
- fix typos in the `Stairs` component comments

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68796b827e1c832f8554fcb07174c0a8