### PR TITLE
Revert particle effects and background to d16d150

### DIFF
--- a/components/coupled-interface/App.jsx
+++ b/components/coupled-interface/App.jsx
@@ -6,17 +6,20 @@ import FBOParticles from "./FBOParticles";
 const Scene = () => (
   <Canvas
     camera={{ position: [1.5, 1.5, 2.5] }}
-    gl={{ alpha: true }}
     style={{ background: "transparent" }}
+    // style={{ background: "black" }}
   >
     <ambientLight intensity={0.8} />
-    <FBOParticles
+    <FBOParticles 
+      // color="#FF5F1F"
       color="#00CED1"
-      position={[-1.5, 0, 0]}
-      timeOffset={0}
-      count={10000}
-      scale={1.3}
-      opacity={0.85}
+      // color="#00FF94" 
+      // color="#FF5F1F"
+      position={[-1.5, 0, 0]} 
+      timeOffset={0} 
+      count={10000} 
+      scale={1.3} 
+      opacity={0.01}
     />
     {/* <FBOParticles 
       color="#FF5F1F"
@@ -34,13 +37,14 @@ const Scene = () => (
       scale={0.8} 
       opacity={0.95}
     /> */}
-    <FBOParticles
-      color="#00CED1"
-      position={[0, -1.5, 0]}
-      timeOffset={10}
-      count={10000}
-      scale={0.8}
-      opacity={0.85}
+    <FBOParticles 
+      // color="#4682B4" 
+      color="#FF5F1F"
+      position={[0, -1.5, 0]} 
+      timeOffset={10} 
+      count={10000} 
+      scale={0.8} 
+      opacity={0.95}
     />
     {/* <FBOParticles 
       color="#00FF94" // "#4682B4" 

--- a/components/coupled-interface/fragmentShader.js
+++ b/components/coupled-interface/fragmentShader.js
@@ -11,7 +11,8 @@ const fragmentShader = `
     
     vec3 color = uColor * strength;
     
-    float alpha = strength * uOpacity;
+    // Use the new uOpacity uniform, but ensure it doesn't make particles disappear
+    float alpha = strength * max(uOpacity, 0.5);
 
     gl_FragColor = vec4(color, alpha);
   }


### PR DESCRIPTION
Restore components/coupled-interface/App.jsx and fragmentShader.js to the state before particle color and canvas background changes.

https://claude.ai/code/session_018a1qbPsEK9xDr9xVqGDfxE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering tweaks confined to the particle demo scene and fragment shader; no data, auth, or backend behavior changes.
> 
> **Overview**
> Tweaks the `coupled-interface` particle scene rendering by removing the explicit `gl={{ alpha: true }}` setting and keeping the canvas background transparent.
> 
> Updates particle appearance by changing colors/opacity values in `App.jsx` (notably dropping one system’s `opacity` to `0.01`) and modifying `fragmentShader.js` to clamp `uOpacity` with `max(uOpacity, 0.5)` so shader alpha never falls below 50% of `strength`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbe5c03c221bf779baeba46f8f1a0fb35535c5cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->